### PR TITLE
fix v0.1.5 deps

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,6 @@
 conda_forge_output_validation: true
 bot:
-  automerge: true
+  automerge: false
 github:
   branch_name: main
   tooling_branch_name: main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,9 +87,9 @@ test:
     - tests/testthat/
     - tests/testthat.R
   commands:
-    - $R -e "library('vetiver')"                                         # [not win]
+    - $R -e "library('vetiver')"                                # [not win]
     - $R -e "testthat::test_file('tests/testthat.R')"           # [not win]
-    - "\"%R%\" -e \"library('vetiver')\""                                # [win]
+    - "\"%R%\" -e \"library('vetiver')\""                       # [win]
     - "\"%R%\" -e \"testthat::test_file('tests/testthat.R')\""  # [win]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/
@@ -35,6 +35,7 @@ requirements:
     - r-httr
     - r-jsonlite
     - r-lifecycle
+    - r-magrittr >= 2.0.3
     - r-pins >=1.0.0
     - r-plumber >=1.0.0
     - r-purrr
@@ -56,6 +57,7 @@ requirements:
     - r-httr
     - r-jsonlite
     - r-lifecycle
+    - r-magrittr >= 2.0.3
     - r-pins >=1.0.0
     - r-plumber >=1.0.0
     - r-purrr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,9 +70,16 @@ requirements:
     - r-withr
 
 test:
+  requires:
+    - r-testthat >=3.0.0
+  source_files:
+    - tests/testthat/
+    - tests/testthat/testthat.R
   commands:
-    - $R -e "library('vetiver')"           # [not win]
-    - "\"%R%\" -e \"library('vetiver')\""  # [win]
+    - $R -e "library('vetiver')"                          # [not win]
+    - $R -e "testthat::test_package('vetiver')"           # [not win]
+    - "\"%R%\" -e \"library('vetiver')\""                 # [win]
+    - "\"%R%\" -e \"testthat::test_package('vetiver')\""  # [win]
 
 about:
   home: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - r-httr
     - r-jsonlite
     - r-lifecycle
-    - r-magrittr >= 2.0.3
+    - r-magrittr >=2.0.3
     - r-pins >=1.0.0
     - r-plumber >=1.0.0
     - r-purrr
@@ -57,7 +57,7 @@ requirements:
     - r-httr
     - r-jsonlite
     - r-lifecycle
-    - r-magrittr >= 2.0.3
+    - r-magrittr >=2.0.3
     - r-pins >=1.0.0
     - r-plumber >=1.0.0
     - r-purrr

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,12 +74,12 @@ test:
     - r-testthat >=3.0.0
   source_files:
     - tests/testthat/
-    - tests/testthat/testthat.R
+    - tests/testthat.R
   commands:
     - $R -e "library('vetiver')"                                         # [not win]
-    - $R -e "testthat::test_file('tests/testthat/testthat.R')"           # [not win]
+    - $R -e "testthat::test_file('tests/testthat.R')"           # [not win]
     - "\"%R%\" -e \"library('vetiver')\""                                # [win]
-    - "\"%R%\" -e \"testthat::test_file('tests/testthat/testthat.R')\""  # [win]
+    - "\"%R%\" -e \"testthat::test_file('tests/testthat.R')\""  # [win]
 
 about:
   home: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,6 +72,12 @@ requirements:
 test:
   requires:
     - r-testthat >=3.0.0
+    - r-caret
+    - r-dplyr
+    - r-mlr3
+    - r-ranger
+    - r-workflows
+    - r-xgboost
   source_files:
     - tests/testthat/
     - tests/testthat.R

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,10 +76,12 @@ test:
     - r-dplyr
     - r-mlr3
     - r-mlr3learners
+    - r-modeldata
     - r-ranger
     - r-slider >=0.2.2
     - r-workflows
     - r-xgboost
+    - r-yardstick
   source_files:
     - tests/testthat/
     - tests/testthat.R

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -76,10 +76,10 @@ test:
     - tests/testthat/
     - tests/testthat/testthat.R
   commands:
-    - $R -e "library('vetiver')"                          # [not win]
-    - $R -e "testthat::test_package('vetiver')"           # [not win]
-    - "\"%R%\" -e \"library('vetiver')\""                 # [win]
-    - "\"%R%\" -e \"testthat::test_package('vetiver')\""  # [win]
+    - $R -e "library('vetiver')"                                         # [not win]
+    - $R -e "testthat::test_file('tests/testthat/testthat.R')"           # [not win]
+    - "\"%R%\" -e \"library('vetiver')\""                                # [win]
+    - "\"%R%\" -e \"testthat::test_file('tests/testthat/testthat.R')\""  # [win]
 
 about:
   home: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,6 +79,7 @@ test:
     - r-modeldata
     - r-ranger
     - r-slider >=0.2.2
+    - r-vdiffr
     - r-workflows
     - r-xgboost
     - r-yardstick

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,7 +75,9 @@ test:
     - r-caret
     - r-dplyr
     - r-mlr3
+    - r-mlr3learners
     - r-ranger
+    - r-slider >=0.2.2
     - r-workflows
     - r-xgboost
   source_files:


### PR DESCRIPTION
Last build passed and automerged, but did not properly include new dependency. This fixes dependency, disables bot automerge, and enables running `testthat` tests.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
