### PR TITLE
Test deps

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/
@@ -74,10 +74,13 @@ test:
     - r-testthat >=3.0.0
     - r-caret
     - r-dplyr
+    - r-flexdashboard
     - r-mlr3
     - r-mlr3learners
     - r-modeldata
     - r-ranger
+    - r-rmarkdown >=2.12
+    - r-rsconnect
     - r-slider >=0.2.2
     - r-vdiffr
     - r-workflows

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,10 +90,10 @@ test:
     - tests/testthat/
     - tests/testthat.R
   commands:
-    - $R -e "library('vetiver')"                                                       # [not win]
-    - $R -e "testthat::test_file('tests/testthat.R', c('progress', 'fail'))"           # [not win]
-    - "\"%R%\" -e \"library('vetiver')\""                                              # [win]
-    - "\"%R%\" -e \"testthat::test_file('tests/testthat.R', c('progress', 'fail'))\""  # [win]
+    - $R -e "library('vetiver')"                                                                # [not win]
+    - $R -e "testthat::test_file('tests/testthat.R', c('location', 'check', 'fail'))"           # [not win]
+    - "\"%R%\" -e \"library('vetiver')\""                                                       # [win]
+    - "\"%R%\" -e \"testthat::test_file('tests/testthat.R', c('location', 'check', 'fail'))\""  # [win]
 
 about:
   home: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,10 +90,10 @@ test:
     - tests/testthat/
     - tests/testthat.R
   commands:
-    - $R -e "library('vetiver')"                                # [not win]
-    - $R -e "testthat::test_file('tests/testthat.R')"           # [not win]
-    - "\"%R%\" -e \"library('vetiver')\""                       # [win]
-    - "\"%R%\" -e \"testthat::test_file('tests/testthat.R')\""  # [win]
+    - $R -e "library('vetiver')"                                                       # [not win]
+    - $R -e "testthat::test_file('tests/testthat.R', c('progress', 'fail'))"           # [not win]
+    - "\"%R%\" -e \"library('vetiver')\""                                              # [win]
+    - "\"%R%\" -e \"testthat::test_file('tests/testthat.R', c('progress', 'fail'))\""  # [win]
 
 about:
   home: https://vetiver.tidymodels.org/, https://github.com/tidymodels/vetiver


### PR DESCRIPTION
Test dependencies changed. Adding `FailReporter` to enable tests to fail the CI.

## Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
